### PR TITLE
MQ timeout and endpoint configuration

### DIFF
--- a/libraries/grpc/grpc.cpp
+++ b/libraries/grpc/grpc.cpp
@@ -15,40 +15,40 @@
 
 #include <koinos/grpc/grpc.hpp>
 
-#define _GRPC_SYNC_METHOD_DEFINITION( r, svc, method )                                \
-::grpc::Status BOOST_PP_CAT( svc, _service )::method( ::grpc::ServerContext* context, \
-const ::koinos::rpc::svc::BOOST_PP_CAT(method, _request*) request,                    \
-::koinos::rpc::svc::BOOST_PP_CAT(method, _response*) response )                       \
-{                                                                                     \
-   try                                                                                \
-   {                                                                                  \
-      rpc::svc::BOOST_PP_CAT( svc, _request ) req;                                    \
-      BOOST_PP_CAT(*req.mutable_, method)() = *request;                               \
-      auto future = _client.rpc( util::service::svc,                                  \
-         util::converter::as< std::string >( req ), 750ms, mq::retry_policy::none );  \
-      rpc::svc::BOOST_PP_CAT( svc, _response ) resp;                                  \
-      resp.ParseFromString( future.get() );                                           \
-      KOINOS_ASSERT( BOOST_PP_CAT( resp.has_, method )(),                             \
-         koinos::exception, "unexpected response type" );                             \
-      *response = resp.method();                                                      \
-   }                                                                                  \
-   catch ( const koinos::exception& e )                                               \
-   {                                                                                  \
-      LOG(warning) << "An exception has occurred: " << e.get_message();               \
-      return ::grpc::Status( ::grpc::StatusCode::INTERNAL, e.what() );                \
-   }                                                                                  \
-   catch ( const std::exception& e )                                                  \
-   {                                                                                  \
-      LOG(warning) << "An exception has occurred: " << e.what();                      \
-      return ::grpc::Status( ::grpc::StatusCode::INTERNAL, e.what() );                \
-   }                                                                                  \
-   catch ( ... )                                                                      \
-   {                                                                                  \
-      LOG(warning) << "An unknown exception has occurred";                            \
-      return ::grpc::Status( ::grpc::StatusCode::UNKNOWN,                             \
-         "an unknown exception has occurred" );                                       \
-   }                                                                                  \
-   return ::grpc::Status::OK;                                                         \
+#define _GRPC_SYNC_METHOD_DEFINITION( r, svc, method )                                  \
+::grpc::Status BOOST_PP_CAT( svc, _service )::method( ::grpc::ServerContext* context,   \
+const ::koinos::rpc::svc::BOOST_PP_CAT(method, _request*) request,                      \
+::koinos::rpc::svc::BOOST_PP_CAT(method, _response*) response )                         \
+{                                                                                       \
+   try                                                                                  \
+   {                                                                                    \
+      rpc::svc::BOOST_PP_CAT( svc, _request ) req;                                      \
+      BOOST_PP_CAT(*req.mutable_, method)() = *request;                                 \
+      auto future = _client.rpc( util::service::svc,                                    \
+         util::converter::as< std::string >( req ), _timeout, mq::retry_policy::none ); \
+      rpc::svc::BOOST_PP_CAT( svc, _response ) resp;                                    \
+      resp.ParseFromString( future.get() );                                             \
+      KOINOS_ASSERT( BOOST_PP_CAT( resp.has_, method )(),                               \
+         koinos::exception, "unexpected response type" );                               \
+      *response = resp.method();                                                        \
+   }                                                                                    \
+   catch ( const koinos::exception& e )                                                 \
+   {                                                                                    \
+      LOG(warning) << "An exception has occurred: " << e.get_message();                 \
+      return ::grpc::Status( ::grpc::StatusCode::INTERNAL, e.what() );                  \
+   }                                                                                    \
+   catch ( const std::exception& e )                                                    \
+   {                                                                                    \
+      LOG(warning) << "An exception has occurred: " << e.what();                        \
+      return ::grpc::Status( ::grpc::StatusCode::INTERNAL, e.what() );                  \
+   }                                                                                    \
+   catch ( ... )                                                                        \
+   {                                                                                    \
+      LOG(warning) << "An unknown exception has occurred";                              \
+      return ::grpc::Status( ::grpc::StatusCode::UNKNOWN,                               \
+         "an unknown exception has occurred" );                                         \
+   }                                                                                    \
+   return ::grpc::Status::OK;                                                           \
 }
 
 #define GRPC_SYNC_METHOD_DEFINITIONS( svc, args ) BOOST_PP_SEQ_FOR_EACH( _GRPC_SYNC_METHOD_DEFINITION, svc, args )
@@ -71,7 +71,7 @@ void callbacks::PostSynchronousRequest( grpc_impl::ServerContext* context ) {}
 
 // Mempool service implementation
 
-mempool_service::mempool_service( mq::client& c ) : _client( c ) {}
+mempool_service::mempool_service( mq::client& c, std::chrono::seconds timeout ) : _client( c ), _timeout( timeout ) {}
 
 GRPC_SYNC_METHOD_DEFINITIONS( mempool,
    (get_pending_transactions)
@@ -80,7 +80,7 @@ GRPC_SYNC_METHOD_DEFINITIONS( mempool,
 
 // Account history implementation
 
-account_history_service::account_history_service( mq::client& c ) : _client( c ) {}
+account_history_service::account_history_service( mq::client& c, std::chrono::seconds timeout ) : _client( c ), _timeout( timeout ) {}
 
 GRPC_SYNC_METHOD_DEFINITIONS( account_history,
    (get_account_history)

--- a/libraries/grpc/include/koinos/grpc/grpc.hpp
+++ b/libraries/grpc/include/koinos/grpc/grpc.hpp
@@ -42,7 +42,7 @@ private:
 class mempool_service final : public mempool::Service {
 public:
 
-   explicit mempool_service( mq::client& c );
+   explicit mempool_service( mq::client& c, std::chrono::seconds timeout );
 
    GRPC_SYNC_METHOD_DECLARATIONS( mempool,
       (get_pending_transactions)
@@ -52,12 +52,13 @@ public:
 private:
 
    mq::client& _client;
+   std::chrono::seconds _timeout;
 };
 
 class account_history_service final : public account_history::Service {
 public:
 
-   explicit account_history_service( mq::client& c );
+   explicit account_history_service( mq::client& c, std::chrono::seconds timeout );
 
    GRPC_SYNC_METHOD_DECLARATIONS( account_history,
       (get_account_history)
@@ -66,6 +67,7 @@ public:
 private:
 
    mq::client& _client;
+   std::chrono::seconds _timeout;
 };
 
 


### PR DESCRIPTION
Resolves #2.
Resolves #3.

## Brief description
Adds `mq-timeout` and `endpoint` to the configuration of the microservice with regards to arguments and configuration file.

## Checklist

- [ ] I have built this pull request locally
- [ ] I have ran the unit tests locally
- [ ] I have manually tested this pull request
- [ ] I have reviewed my pull request
- [ ] I have added any relevant tests

**Note:** Review and merge only after PR #5.